### PR TITLE
Remove markdown

### DIFF
--- a/Templates/Applications/SAMLApplication.json
+++ b/Templates/Applications/SAMLApplication.json
@@ -604,8 +604,7 @@
       "after": {
         "name": "initiationBy",
         "inline": true
-      },
-      "markdown": "inline"
+      }
     },
     "initiationTypeLabel": {
       "content": "Connection Type"


### PR DESCRIPTION
The markdown property of a static element doesn't actually do anything anymore. This can only be handled through the property flags.