### PR TITLE
Call fixes

### DIFF
--- a/Templates/Applications/Office365.json
+++ b/Templates/Applications/Office365.json
@@ -545,15 +545,20 @@
       ]
     },
     "wsFedSigningAlgorithm": {
-      "label": "WS-Fed Signing Algorithm",
+      "label": "Signing Algorithm",
       "controlType": "radiogroup",
       "defaultValue": "SHA2",
+      "noMargin": true,
+      "properties":
+      {
+        "inline": true,
+        "stack": "small:medium:small"
+      },
       "options":
       [
         "SHA1",
         "SHA2"
-      ],
-      "visible": false
+      ]
     }
   },
   "statics":
@@ -1247,7 +1252,7 @@
         },
         "signingCertNameFieldset",
         "signingCertSerialNoFieldset",
-        "signingAlgorithm"
+        "wsFedSigningAlgorithm"
       ]
     },
     "templateRoot":
@@ -1267,11 +1272,9 @@
         "audience",
         "spLoginUrl",
         "wsFedVersion",
-        "wsFedSigningAlgorithm",
         "assertionWillBeValid",
         "assertionOffsetMinutes",
         "signSamlElements",
-        "encryptSamlAssertion",
         {
           "name": "defaultHeader",
           "content": "WS-TRUST ENDPOINTS"


### PR DESCRIPTION
Remove encrypt SAML assertion from the template.
SigningAlgorithm now is for wsfed and not for saml.