### PR TITLE
Rework certificate section

### DIFF
--- a/Templates/Applications/Office365.json
+++ b/Templates/Applications/Office365.json
@@ -483,23 +483,13 @@
     {
       "states": "Sign WS-Fed Assertion",
       "controlType": "switch",
-      "defaultValue": true,
-      "notify":
-      {
-        "signSamlElementsOn": true
-      }
+      "defaultValue": true
     },
     "signSamlMessage":
     {
       "states": "Sign WS-Fed Message",
       "controlType": "switch",
-      "defaultValue": false,
-      "order": "signSamlElementsCallout",
-      "notify":
-      {
-        "signSamlElementsOn": true
-      },
-      "validate": "(#false and signSamlAssertion:#false) or signingCertOptions:@requireSigningCert"
+      "defaultValue": false
     },
     "spLoginUrl":
     {
@@ -936,22 +926,6 @@
       ],
       "stack@providersInfo": "medium"
     },
-    "signSamlElementsCallout":
-    {
-      "after": "signingCertOptions",
-      "stack": "small",
-      "modify":
-      {
-        "signSamlElementsOff":
-        {
-          "visible": false
-        },
-        "signSamlElementsOn":
-        {
-          "visible": true
-        }
-      }
-    },
     "spLoginUrlTooltip":
     {
       "content": "The O365 Login URL is optional.",
@@ -1222,14 +1196,6 @@
     },
     "signSamlElements":
     {
-      "notify":
-      {
-        "signSamlElementsOff":
-        {
-          "value.signSamlAssertion": false,
-          "value.signSamlMessage": false
-        }
-      },
       "order":
       [
         "signSamlAssertion",
@@ -1260,7 +1226,9 @@
         "signingCertNameFieldset",
         "signingCertSerialNoFieldset",
         "wsFedSigningAlgorithm"
-      ]
+      ],
+      "pad": "::small",
+      "validate": "requireSigningCert"
     },
     "templateRoot":
     {
@@ -1281,6 +1249,7 @@
         "wsFedVersion",
         "assertionWillBeValid",
         "assertionOffsetMinutes",
+        "signingCertOptions",
         "signSamlElements",
         {
           "name": "defaultHeader",

--- a/Templates/Applications/Salesforce.json
+++ b/Templates/Applications/Salesforce.json
@@ -285,12 +285,7 @@
     {
       "states": "Sign SAML Message",
       "controlType": "switch",
-      "defaultValue": false,
-      "order": "signSamlElementsCallout",
-      "notify":
-      {
-        "signSamlElementsOn": true
-      }
+      "defaultValue": false
     },
     "assertionConsumerService":
     {
@@ -581,7 +576,13 @@
       [
         {
           "name": "static:label",
-          "content": "IdP Signing Certificate"
+          "content": "IdP Signing Certificate",
+          "inline": true,
+          "pad": ":small"
+        },
+        {
+          "name": "other:importance",
+          "inline": true
         },
         "signingCertName"
       ]
@@ -604,22 +605,6 @@
         "signingCertDownloadAction"
       ],
       "stack@providersInfo": "medium"
-    },
-    "signSamlElementsCallout":
-    {
-      "after": "signingCertOptions",
-      "stack": "small",
-      "modify":
-      {
-        "signSamlElementsOff":
-        {
-          "visible": false
-        },
-        "signSamlElementsOn":
-        {
-          "visible": true
-        }
-      }
     },
     "spLoginUrlToolTip":
     {
@@ -733,6 +718,26 @@
       }
     }
   },
+  "validation":
+  {
+    "requireSigningCert":
+    {
+      "constrain":
+      {
+        "signingCert": "is.required"
+      },
+      "nested":
+      {
+        "signingCert":
+        {
+          "constrain":
+          {
+            "value": "is.required"
+          }
+        }
+      }
+    }
+  },
   "groups":
   {
     "attributeItem":
@@ -782,17 +787,12 @@
         "signingCertNameFieldset",
         "signingCertSerialNoFieldset",
         "signingAlgorithm"
-      ]
+      ],
+      "pad": "::small",
+      "validate": "requireSigningCert"
     },
     "signSamlElements":
     {
-      "notify":
-      {
-        "signSamlElementsOff":
-        {
-          "value.signSamlMessage": false
-        }
-      },
       "order":
       [
         "signSamlMessage"
@@ -854,6 +854,7 @@
         "issuer",
         "assertionWillBeValid",
         "signSamlElements",
+        "signingCertOptions",
         "spLoginUrl",
         "recipient",
         "attributesHeader",


### PR DESCRIPTION
Certificate is always required.
Certificate selection section is always visible.
Removed notifiers and modifiers from Assertion and Messages swtiches.